### PR TITLE
docs: add internal documentation for banner components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,150 @@
+# 🤝 Contribuir a WoodBench | Contributing to WoodBench
+
+WoodBench es un blog de carpintería hecho con React y Vite, pensado para inspirar, enseñar y compartir experiencias reales con la madera.
+
+Gracias por tu interés en colaborar con **WoodBench**.
+Toda sugerencia, mejora, corrección o idea es más que bienvenida.
+
+WoodBench is a woodworking blog built with React and Vite, designed to inspire, teach, and share real-life experiences with wood.
+
+Thanks for your interest in contributing to **WoodBench**!
+Suggestions, improvements, corrections, and new ideas are all welcome.
+
+---
+
+## 🛠️ Tecnologías utilizadas | Tech Stack
+
+- React
+- Vite
+- Material UI (MUI)
+- React Router
+- i18next
+- React Markdown
+- Vercel
+
+---
+
+## 🧑‍💻 Configuración local | Local Setup
+
+```bash
+git clone https://github.com/woodbench/woodbench-frontend.git
+cd woodbench-frontend
+npm install
+npm run dev
+```
+
+---
+
+## 🛠️ ¿Cómo contribuir? | How to contribute
+
+### 🧪 1. Explorá el proyecto | Explore the project
+
+Antes de enviar una propuesta, revisá el sitio [thewoodbench.com](https://thewoodbench.com)  
+o explorá el código en este repositorio.  
+Te puede ayudar a entender el enfoque, estilo y tono del blog.
+
+Before submitting a proposal, check out the website or explore the code.  
+It helps you understand the tone, structure, and approach.
+
+---
+
+### 🐛 2. Issues
+
+Si encontrás un error o querés sugerir una mejora, podés:
+
+- Abrir un nuevo issue
+- Comentar en un issue ya existente
+- Proponer un nuevo contenido o sección
+
+If you find a bug or want to suggest an improvement:
+
+- Open a new issue
+- Comment on an existing one
+- Propose a new topic or section
+
+---
+
+### 🌱 3. Branches | Ramas
+
+#### 🌿 Convención de nombres | Naming convention
+
+Usamos este esquema para nombrar ramas de desarrollo:
+
+We use this naming scheme for development branches:
+
+- `main` – Producción | Production branch
+- `stable` – Ultima version estable | last stable version
+- `test` – Pruebas opcionales | Optional testing
+- `dev` – Desarrollo principal | Main development
+- `release/x.y.z` – Preparación de versión estable | Release candidate
+- `feature/nombre-de-feature` – Nueva funcionalidad | New feature
+- `bugfix/nombre-del-bug` – Corrección de error | Bug fix
+- `hotfix/urgencia` – Arreglo urgente en producción | Emergency fix
+- `refactor/nombre-del-refactor` – Mejora interna sin cambiar funcionalidad | internal refactor
+- `docs/nombre-documentacion` – Documentacion | Documentation
+
+Ejemplos | Examples:
+
+- `feature/formulario-descarga`
+- `bugfix/imagen-no-carga`
+- `hotfix/fix-footer`
+
+---
+
+### ✅ 4. Pull Requests
+
+Una vez que tu rama esté lista:
+
+1. Asegurate de probar los cambios.
+2. Enviá el pull request desde tu rama hacia `dev`.
+3. Agregá una descripción clara de lo que hiciste.
+
+Make sure to test your changes, then open a PR to `dev` with a clear description.
+
+---
+
+## 🧾 Commits
+
+- En lo posible, escribí mensajes cortos, descriptivos y en presente.  
+  Prefer short, descriptive commit messages in the present tense.
+
+```bash
+✅ add download section
+🐛 fix wrong i18n fallback
+📝 update blog post styles
+```
+
+---
+
+## 📤 Pull Requests
+
+Por favor incluí:  
+Please include:
+
+- Qué cambiaste / What you changed
+- Por qué lo cambiaste / Why you changed it
+- Screenshots (si aplica) / Screenshots (if applicable)
+
+---
+
+## 📁 Estructura del proyecto | Project Structure
+
+```
+src/
+├── components/      → Componentes reutilizables / Reusable components
+├── pages/           → Páginas del sitio / Site pages
+├── content/blog/    → Entradas en formato markdown / Blog posts in .md
+├── routes/          → Rutas con React Router
+├── theme/           → Configuración de MUI
+└── i18n/            → Archivos de internacionalización
+```
+
+---
+
+## 📌 Notas finales | Final Notes
+
+Este proyecto está abierto a sugerencias, mejoras y nuevas ideas.  
+This project is open to suggestions, improvements, and new ideas.
+
+👉 Gracias por ayudar a que WoodBench crezca.  
+👉 Thanks for helping WoodBench grow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ We use this naming scheme for development branches:
 - `hotfix/urgencia` – Arreglo urgente en producción | Emergency fix
 - `refactor/nombre-del-refactor` – Mejora interna sin cambiar funcionalidad | internal refactor
 - `docs/nombre-documentacion` – Documentacion | Documentation
+- `chore/nombre-del-chore` – Tareas menores o de mantenimiento (actualización de dependencias, limpieza, scripts) | Minor or maintenance tasks (dependencies updates, cleaning, scripts)
 
 Ejemplos | Examples:
 

--- a/docs/components/common/banner/Banner.en.md
+++ b/docs/components/common/banner/Banner.en.md
@@ -1,0 +1,69 @@
+# 📸 `Banner` – Main Header Component
+
+🔗 [Versión en español](./Banner.es.md)
+
+This component displays a visual banner on the homepage, composed of a background image, an overlay (`BannerOverlay`), and central content (`BannerContent`). It’s the first visual element a visitor sees.
+
+---
+
+## ✨ Features
+
+- Full-width background image.
+- Overlay to darken the background (separate component).
+- Content area with title, subtitle, inspiration text, and a button (separate component).
+- Internationalization support via `i18next`.
+
+---
+
+## 🧩 Usage
+
+```jsx
+import { Banner } from './Banner';
+
+<Banner />;
+```
+
+This component does not receive props. All content is extracted from translation files using `useTranslation()`.
+
+---
+
+## 🧠 Dependencies
+
+- [`@mui/material`](https://mui.com/)
+- [`react-i18next`](https://react.i18next.com/)
+- Image: `bannerTopHome.webp`
+
+---
+
+## 🧱 Related Components
+
+- [`BannerOverlay`](./BannerOverlay.jsx): adds a visual layer over the image.
+- [`BannerContent`](./BannerContent.jsx): contains the text, button, and layout of the banner’s main content.
+
+---
+
+## 🌐 Required Translations (JSON keys)
+
+```json
+"banner": {
+  "alt": "Alternative text for the banner image",
+  "title": "Banner title",
+  "subtitle": "Banner subtitle",
+  "inspiration": "Motivational or inspirational text",
+  "button": "Button text"
+}
+```
+
+---
+
+## 📁 File Location
+
+```
+src/components/pages/home/Banner.jsx
+```
+
+---
+
+## 🏷️ Tags
+
+`component`, `home`, `banner`, `mui`, `i18n`, `visual`, `hero section`

--- a/docs/components/common/banner/Banner.es.md
+++ b/docs/components/common/banner/Banner.es.md
@@ -1,0 +1,69 @@
+# 📸 `Banner` – Componente de encabezado principal
+
+🔗 [English version](./Banner.en.md)
+
+Este componente muestra un banner visual en la página principal, compuesto por una imagen de fondo, una superposición (`BannerOverlay`) y contenido central (`BannerContent`). Es el primer punto visual que ve el visitante.
+
+---
+
+## ✨ Características
+
+- Imagen de fondo a pantalla completa.
+- Superposición para oscurecer el fondo (componente separado).
+- Contenido con título, subtítulo, inspiración y botón (componente separado).
+- Soporte para internacionalización (i18next).
+
+---
+
+## 🧩 Uso
+
+```jsx
+import { Banner } from './Banner';
+
+<Banner />;
+```
+
+Este componente no recibe props. Todo el contenido se extrae desde archivos de traducción usando `useTranslation()`.
+
+---
+
+## 🧠 Dependencias
+
+- [`@mui/material`](https://mui.com/)
+- [`react-i18next`](https://react.i18next.com/)
+- Imagen: `bannerTopHome.webp`
+
+---
+
+## 🧱 Componentes relacionados
+
+- [`BannerOverlay`](./BannerOverlay.jsx): agrega una capa visual encima de la imagen.
+- [`BannerContent`](./BannerContent.jsx): contiene el texto, botón y estructura visual del contenido.
+
+---
+
+## 🌐 Traducciones necesarias (en archivos JSON)
+
+```json
+"banner": {
+  "alt": "Texto alternativo para la imagen del banner",
+  "title": "Título del banner",
+  "subtitle": "Subtítulo del banner",
+  "inspiration": "Texto motivacional o inspiracional",
+  "button": "Texto del botón"
+}
+```
+
+---
+
+## 📁 Ubicación
+
+```
+src/components/pages/home/Banner.jsx
+```
+
+---
+
+## 🏷️ Tags
+
+`component`, `home`, `banner`, `mui`, `i18n`, `visual`, `hero section`

--- a/workflow.md
+++ b/workflow.md
@@ -1,0 +1,94 @@
+# 🧭 WoodBench Branch Workflow
+
+Este documento explica cómo manejamos las ramas en el proyecto **WoodBench**.  
+El objetivo es mantener un desarrollo organizado, controlado y fácil de revertir en caso de errores.
+
+---
+
+## 🌳 Estructura de ramas
+
+```
+tu-rama → dev → main → stable
+                      ↑
+                    (test)
+```
+
+| Rama      | Descripción |
+|-----------|-------------|
+| `dev`     | Rama principal de desarrollo. Todos los Pull Requests van acá.  
+| `main`    | Rama de producción. Lo que está publicado online.  
+| `stable`  | Última versión conocida como 100% estable y segura.  
+| `test`    | (Opcional) Rama para pruebas antes de subir a `main`. Actualmente no se usa.
+
+---
+
+## 🔁 Flujo de trabajo
+
+### 1. Crear tu rama desde `dev`
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/nombre-de-la-tarea
+```
+
+### 2. Subir tus cambios
+
+```bash
+git add .
+git commit -m "feat: describe el cambio"
+git push origin feature/nombre-de-la-tarea
+```
+
+### 3. Crear un Pull Request (PR)
+
+- Base branch: `dev`
+- Compare: la rama que creaste
+
+---
+
+## 🚀 Publicar en producción
+
+Cuando el desarrollo está validado y listo:
+
+```bash
+# Desde la rama main
+git checkout main
+git pull origin main
+git merge dev
+git push origin main
+```
+
+Esto actualiza la producción (Vercel o el entorno que uses).
+
+---
+
+## ✅ Marcar como versión estable
+
+Cuando confirmás que lo publicado en `main` funciona correctamente:
+
+```bash
+git checkout stable
+git pull origin stable
+git merge main
+git push origin stable
+```
+
+`stable` guarda la última versión totalmente confiable.
+
+---
+
+## 🆘 ¿Y si algo falla en producción?
+
+Podés revertir fácilmente usando la rama `stable`:
+
+```bash
+git checkout main
+git pull origin main
+git merge stable
+git push origin main
+```
+
+Así restaurás la última versión buena sin necesidad de investigar errores urgentes.
+
+---


### PR DESCRIPTION
## 🔍 Overview

This PR adds internal documentation for the Banner components, including usage guidelines, props explanation, and translation considerations.

The goal is to help future contributors understand how the banners work and how to use or extend them consistently across the project.

---

## ✅ Related Issues

- None

---

## 🛠️ Type of Change

- [x] Documentation update 📝

---

## 🔁 Changes Made

- Created markdown documentation files for banners
- Explained props, usage patterns, and translation keys
- Clarified responsive behavior where relevant

---

## 📋 Checklist

- [x] Follows documentation style and format
- [x] File(s) placed in the correct `docs/` location
- [x] Reviewed for clarity and structure
- [x] PR targets the `dev` branch
